### PR TITLE
Update deps from dependabot PRs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 APScheduler==3.6.3
 beautifulsoup4==4.9.1
 bs4==0.0.1
-certifi==2020.4.5.1
+certifi==2022.12.7
 chardet==3.0.4
 click==7.1.2
 Flask==1.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ Flask==1.1.2
 gunicorn==20.0.4
 idna==2.9
 itsdangerous==1.1.0
-Jinja2==2.11.2
+Jinja2==2.11.3
 MarkupSafe==1.1.1
 numpy==1.22.0
 pandas==1.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.2
 MarkupSafe==1.1.1
-numpy==1.18.5
+numpy==1.22.0
 pandas==1.0.4
 python-dateutil==2.8.1
 python-dotenv==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,5 +19,5 @@ requests==2.23.0
 six==1.15.0
 soupsieve==2.0.1
 tzlocal==2.1
-urllib3==1.25.9
+urllib3==1.26.5
 Werkzeug==1.0.1


### PR DESCRIPTION
> [!NOTE]
> Changelogs/release notes can be found in the descriptions of the PRs linked below.

Updated modules:

- `certifi`: 2020.4.5.1 => 2022.12.7 (#6)
- `numpy`: 1.18.5 => 1.22.0 (#4)
- `urllib3`: 1.25.8 => 1.26.5 (#3)
- `jinja2`: 2.11.2 => 2.11.3 (#2)